### PR TITLE
Stabilize services

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -132,6 +132,7 @@ FLINK_VERSION = "1.9.0"
 SCALA_VERSION = "2.11"
 
 RULES_JVM_EXTERNAL_TAG = "3.0"
+
 RULES_JVM_EXTERNAL_SHA = "62133c125bf4109dfd9d2af64830208356ce4ef8b165a6ef15bbff7460b35c3a"
 
 http_archive(
@@ -791,6 +792,6 @@ go_repository(
 go_repository(
     name = "com_github_romnnn_flags4urfavecli",
     importpath = "github.com/romnnn/flags4urfavecli",
-    sum = "h1:jm3PWa/6Q9AUXNUFjeIjOAtlPwJ3JTlKVrCmbQbP3yQ=",
-    version = "v0.1.0",
+    sum = "h1:1s6q1ZYyBLbh+1YrcXKaugZ6u5MSq9R763oVpkwNU2I=",
+    version = "v0.1.1",
 )

--- a/auxiliary/producers/replayer/README.md
+++ b/auxiliary/producers/replayer/README.md
@@ -2,3 +2,13 @@ For debugging, use
 ```bash
 bazel run //auxiliary/producers/replayer -- --port 8080 --mode constant --log debug
 ```
+
+For your local mongoDB without authentication, use:
+```bash
+bazel run //auxiliary/producers/replayer -- --mongodb-user="" --mongodb-password="" --port 8080
+```
+
+When you want to replay only selected sources:
+```bash
+bazel run //auxiliary/producers/replayer -- --port 8080 --include-sources "livetraindata, plannedtraindata"
+```

--- a/auxiliary/producers/replayer/extractors/mongo.go
+++ b/auxiliary/producers/replayer/extractors/mongo.go
@@ -1,26 +1,27 @@
 package extractors
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"time"
-	"context"
-	"github.com/golang/protobuf/proto"
+
+	pb "github.com/bptlab/cepta/models/grpc/replayer"
 	libdb "github.com/bptlab/cepta/osiris/lib/db"
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/romnnn/bsonpb"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
-	"github.com/golang/protobuf/ptypes"
 	"go.mongodb.org/mongo-driver/mongo"
-	"github.com/romnnn/bsonpb"
-	pb "github.com/bptlab/cepta/models/grpc/replayer"
 )
 
 // MongoExtractor ...
 type MongoExtractor struct {
-	Proto proto.Message
-	DB *libdb.MongoDB
-	debug bool
-	cur *mongo.Cursor
+	Proto       proto.Message
+	DB          *libdb.MongoDB
+	debug       bool
+	cur         *mongo.Cursor
 	unmarshaler bsonpb.Unmarshaler
 	IDFieldName string
 }
@@ -79,7 +80,7 @@ func (ex *MongoExtractor) SetDebug(debug bool) {
 // NewMongoExtractor ...
 func NewMongoExtractor(db *libdb.MongoDB, proto proto.Message) *MongoExtractor {
 	return &MongoExtractor{
-		DB: db,
+		DB:    db,
 		Proto: proto,
 	}
 }
@@ -103,7 +104,7 @@ func (ex *MongoExtractor) buildAggregation(queryOptions *ReplayQuery) bson.A {
 	aggregation := bson.A{
 		bson.D{{"$match", mustMatch}},
 		bson.D{{"$sort", bson.D{{queryOptions.SortColumn, 1}}}}, // Order by column (ascending order)
-		bson.D{{"$skip", queryOptions.Offset}}, // Set offset
+		bson.D{{"$skip", queryOptions.Offset}},                  // Set offset
 	}
 
 	// Set limit
@@ -111,10 +112,8 @@ func (ex *MongoExtractor) buildAggregation(queryOptions *ReplayQuery) bson.A {
 		aggregation = append(aggregation, bson.D{{"$limit", *(queryOptions.Limit)}})
 	}
 
-	fmt.Println(aggregation)
 	return aggregation
 }
-
 
 func mongoTimerangeQuery(column string, timerange *pb.Timerange) bson.D {
 	var constraints bson.D

--- a/auxiliary/producers/replayer/replayer.go
+++ b/auxiliary/producers/replayer/replayer.go
@@ -111,19 +111,13 @@ func (r Replayer) produce() error {
 func (r Replayer) Start(log *logrus.Logger) error {
 	r.log = log.WithField("source", r.SourceName)
 	r.log.Info("Starting to produce")
-	var err error
-	r.producer, err = kafkaproducer.KafkaProducer{}.ForBroker(r.Brokers)
-	if err != nil {
-		log.Warnf("Failed to start kafka producer: %s", err.Error())
-		log.Fatal("Cannot produce events")
-	}
 	defer func() {
 		if err := r.producer.Close(); err != nil {
-			r.log.Println("Failed to close server", err)
+			r.log.Errorf("Failed to close server", err)
 		}
 	}()
 	r.Extractor.SetDebug(r.log.Logger.IsLevelEnabled(logrus.DebugLevel))
-	err = r.produce()
+	err := r.produce()
 	if err != nil {
 		log.Error(err)
 	}

--- a/auxiliary/producers/replayer/replayer.go
+++ b/auxiliary/producers/replayer/replayer.go
@@ -5,9 +5,9 @@ import (
 	"time"
 
 	"github.com/Shopify/sarama"
+	"github.com/bptlab/cepta/auxiliary/producers/replayer/extractors"
 	pb "github.com/bptlab/cepta/models/grpc/replayer"
 	kafkaproducer "github.com/bptlab/cepta/osiris/lib/kafka/producer"
-	"github.com/bptlab/cepta/auxiliary/producers/replayer/extractors"
 	"github.com/bptlab/cepta/osiris/lib/utils"
 	"github.com/golang/protobuf/proto"
 	"github.com/sirupsen/logrus"
@@ -15,20 +15,20 @@ import (
 
 // Replayer ...
 type Replayer struct {
-	Ctrl       chan pb.InternalControlMessageType
+	Ctrl        chan pb.InternalControlMessageType
 	SourceName  string
-	IDFieldName  string
-	Query 	*extractors.ReplayQuery
-	Speed      *int32
-	Active     *bool
-	Repeat     bool
-	Mode       *pb.ReplayType
-	Extractor  extractors.Extractor
-	Topic      string
-	Brokers    []string
-	log        *logrus.Entry
-	running    bool
-	producer   *kafkaproducer.KafkaProducer
+	IDFieldName string
+	Query       *extractors.ReplayQuery
+	Speed       *int32
+	Active      *bool
+	Repeat      bool
+	Mode        *pb.ReplayType
+	Extractor   extractors.Extractor
+	Topic       string
+	Brokers     []string
+	log         *logrus.Entry
+	running     bool
+	producer    *kafkaproducer.KafkaProducer
 }
 
 func (r Replayer) produce() error {
@@ -77,7 +77,7 @@ func (r Replayer) produce() error {
 				if !recentTime.IsZero() {
 					passedTime = newTime.Sub(recentTime)
 				}
-				r.log.Infof("%v have passed since the last event", passedTime)
+				r.log.Debugf("%v have passed since the last event", passedTime)
 				r.producer.Send(r.Topic, r.Topic, sarama.ByteEncoder(eventBytes))
 				r.log.Debugf("Speed is %d, mode is %s", *r.Speed, *r.Mode)
 
@@ -91,7 +91,7 @@ func (r Replayer) produce() error {
 					waitTime = 10
 				}
 
-				r.log.Infof("Produced a message to %s and will sleep for %v seconds", r.Topic, time.Duration(waitTime))
+				r.log.Debugf("Produced a message to %s and will sleep for %v seconds", r.Topic, time.Duration(waitTime))
 				time.Sleep(time.Duration(waitTime))
 				recentTime = newTime
 

--- a/auxiliary/producers/replayer/server.go
+++ b/auxiliary/producers/replayer/server.go
@@ -155,7 +155,7 @@ func serve(ctx *cli.Context, log *logrus.Logger, mongoPtr *libdb.MongoDB) error 
 	*/
 
 	mongoConfig := libdb.MongoDBConfig{}.ParseCli(ctx)
-	mongo, err := libdb.MongoDatabase(&mongoConfig, libcli.ParseTimeout(ctx))
+	mongo, err := libdb.MongoDatabase(&mongoConfig)
 	if err != nil {
 		log.Fatalf("failed to initialize mongo database: %v", err)
 	}

--- a/auxiliary/producers/replayer/server.go
+++ b/auxiliary/producers/replayer/server.go
@@ -436,6 +436,18 @@ func main() {
 			EnvVars: []string{"INCLUDE", "ERRIDS", "MATCH"},
 			Usage:   "ids to be included in the replay",
 		},
+		&cli.StringFlag{
+			Name:    "include-sources",
+			Value:   "",
+			EnvVars: []string{"INCLUDE_SOURCES"},
+			Usage:   "sources to be included in the replay (default: all)",
+		},
+		&cli.StringFlag{
+			Name:    "exclude-sources",
+			Value:   "",
+			EnvVars: []string{"EXCLUDE_SOURCES"},
+			Usage:   "sources to be excluded from the replay (default: none)",
+		},
 		&cli.GenericFlag{
 			Name: "mode",
 			Value: &clivalues.EnumValue{

--- a/auxiliary/producers/replayer/server.go
+++ b/auxiliary/producers/replayer/server.go
@@ -508,29 +508,29 @@ func main() {
 	}...)
 
 	log = logrus.New()
-	go func() {
-		app := &cli.App{
-			Name:    "CEPTA Train data replayer producer",
-			Version: versioning.BinaryVersion(Version, BuildTime),
-			Usage:   "Produces train data events by replaying a database dump",
-			Flags:   cliFlags,
-			Action: func(ctx *cli.Context) error {
+
+	app := &cli.App{
+		Name:    "CEPTA Train data replayer producer",
+		Version: versioning.BinaryVersion(Version, BuildTime),
+		Usage:   "Produces train data events by replaying a database dump",
+		Flags:   cliFlags,
+		Action: func(ctx *cli.Context) error {
+			go func() {
 				level, err := logrus.ParseLevel(ctx.String("log"))
 				if err != nil {
 					log.Warnf("Log level '%s' does not exist.")
 					level = logrus.InfoLevel
 				}
 				log.SetLevel(level)
-				ret := serve(ctx, log, mongo)
-				return ret
-			},
-		}
-		err := app.Run(os.Args)
-		if err != nil {
-			log.Fatal(err)
-		}
-	}()
-
-	<-done
-	log.Info("Exiting")
+				serve(ctx, log, mongo)
+			}()
+			<-done
+			log.Info("Exiting")
+			return nil
+		},
+	}
+	err := app.Run(os.Args)
+	if err != nil {
+		log.Fatal(err)
+	}
 }

--- a/deployment/dev/compose/core.compose.yml
+++ b/deployment/dev/compose/core.compose.yml
@@ -156,6 +156,9 @@ services:
     command:
       - --brokers=kafka:9092
       - --port=9000
+      # Benchmark indicates MongoDB is the bottleneck
+      # - --mode=constant
+      # - --pause=0
       - --postgres-host=postgres
       - --postgres-port=${CEPTA_POSTGRES_PORT}
       - --mongodb-host=mongodb

--- a/deployment/dev/devenv.sh
+++ b/deployment/dev/devenv.sh
@@ -3,8 +3,15 @@
 cd $(dirname $0)
 cd compose
 
-# Build local images first
-bazel run //:build-images
+if [ -z "$BUILD" ]; then
+  echo "Using existing images. To rebuild, run:"
+  echo ""
+  echo "  BUILD=1 deployment/dev/devenv.sh ..args"
+  echo ""
+else
+  # Build local images first
+  bazel run //:build-images
+fi
 
 docker-compose \
   -f core.compose.yml \

--- a/osiris/authentication/server.go
+++ b/osiris/authentication/server.go
@@ -119,31 +119,30 @@ func main() {
 	cliFlags = append(cliFlags, libdb.PostgresDatabaseCliOptions...)
 
 	log = logrus.New()
-	go func() {
-		app := &cli.App{
-			Name:    "CEPTA User management server",
-			Version: versioning.BinaryVersion(Version, BuildTime),
-			Usage:   "manages the user database",
-			Flags:   cliFlags,
-			Action: func(ctx *cli.Context) error {
+	app := &cli.App{
+		Name:    "CEPTA User management server",
+		Version: versioning.BinaryVersion(Version, BuildTime),
+		Usage:   "manages the user database",
+		Flags:   cliFlags,
+		Action: func(ctx *cli.Context) error {
+			go func() {
 				level, err := logrus.ParseLevel(ctx.String("log"))
 				if err != nil {
 					log.Warnf("Log level '%s' does not exist.")
 					level = logrus.InfoLevel
 				}
 				log.SetLevel(level)
-				ret := serve(ctx, log)
-				return ret
-			},
-		}
-		err := app.Run(os.Args)
-		if err != nil {
-			log.Fatal(err)
-		}
-	}()
-
-	<-done
-	log.Info("Exiting")
+				serve(ctx, log)
+			}()
+			<-done
+			log.Info("Exiting")
+			return nil
+		},
+	}
+	err := app.Run(os.Args)
+	if err != nil {
+		log.Fatal(err)
+	}
 }
 
 func serve(ctx *cli.Context, log *logrus.Logger) error {

--- a/osiris/authentication/server.go
+++ b/osiris/authentication/server.go
@@ -115,6 +115,7 @@ func main() {
 
 	cliFlags := []cli.Flag{}
 	cliFlags = append(cliFlags, libcli.CommonCliOptions(libcli.ServicePort, libcli.ServiceLogLevel)...)
+	cliFlags = append(cliFlags, libcli.CommonCliOptions(libcli.ServiceConnectionTolerance)...)
 	cliFlags = append(cliFlags, libdb.PostgresDatabaseCliOptions...)
 
 	log = logrus.New()

--- a/osiris/lib/db/BUILD
+++ b/osiris/lib/db/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//osiris/lib:cli",
         "//models/events:live_train_data_go_proto",
         "//models/events:weather_data_go_proto",
+        "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_golang_protobuf//ptypes/timestamp:go_default_library",
         "@com_github_golang_protobuf//ptypes:go_default_library_gen",
         "@com_github_golang_protobuf//proto:go_default_library",

--- a/osiris/lib/db/mongo.go
+++ b/osiris/lib/db/mongo.go
@@ -43,22 +43,25 @@ func (config MongoDBConfig) ParseCli(ctx *cli.Context) MongoDBConfig {
 var MongoDatabaseCliOptions = libcli.CommonCliOptions(libcli.Mongo)
 
 // MongoDatabase ...
-func MongoDatabase(config *MongoDBConfig) (*MongoDB, error) {
+func MongoDatabase(config *MongoDBConfig, timeoutSec int) (*MongoDB, error) {
 	databaseName := config.Database
-	databaseAuth := fmt.Sprintf("%s:%s", config.User, config.Password)
+	var databaseAuth string
+	if len(config.User+config.Password) > 0 {
+		databaseAuth = fmt.Sprintf("%s:%s@", config.User, config.Password)
+	}
 	databaseHost := fmt.Sprintf("%s:%d", config.Host, config.Port)
-	databaseConnectionURI := fmt.Sprintf("mongodb://%s@%s/?connect=direct", databaseAuth, databaseHost)
+	databaseConnectionURI := fmt.Sprintf("mongodb://%s%s/?connect=direct", databaseAuth, databaseHost)
 	client, err := mongo.NewClient(options.Client().ApplyURI(databaseConnectionURI))
 	if err != nil {
 		log.Fatalf("Failed to create database client: %v (%s:%s)", err, databaseConnectionURI, databaseName)
 	}
-	mctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	mctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutSec)*time.Second)
 	defer cancel()
 	client.Connect(mctx)
 
 	err = client.Ping(mctx, readpref.Primary())
 	if err != nil {
-		log.Fatalf("Could not ping database within 10 seconds: %s (%s:%s)", err.Error(), databaseConnectionURI, databaseName)
+		log.Fatalf("Could not ping database within %d seconds: %s (%s:%s)", timeoutSec, err.Error(), databaseConnectionURI, databaseName)
 	}
 	database := client.Database(databaseName)
 	return &MongoDB{DB: database}, nil

--- a/osiris/lib/db/postgres.go
+++ b/osiris/lib/db/postgres.go
@@ -2,12 +2,15 @@ package db
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 	"text/template"
+	"time"
 
 	libcli "github.com/bptlab/cepta/osiris/lib/cli"
 	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/postgres"
+	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 )
 
@@ -18,23 +21,25 @@ type PostgresDB struct {
 
 // PostgresDBConfig ...
 type PostgresDBConfig struct {
-	Host     string
-	Port     uint
-	User     string
-	Name     string
-	Password string
-	SSLMode  string
+	Host                string
+	Port                uint
+	User                string
+	Name                string
+	Password            string
+	SSLMode             string
+	ConnectionTolerance libcli.ConnectionTolerance
 }
 
 // ParseCli ...
 func (config PostgresDBConfig) ParseCli(ctx *cli.Context) PostgresDBConfig {
 	return PostgresDBConfig{
-		Host:     ctx.String("postgres-host"),
-		Port:     uint(ctx.Int("postgres-port")),
-		User:     ctx.String("postgres-user"),
-		Name:     ctx.String("postgres-name"),
-		Password: ctx.String("postgres-password"),
-		SSLMode:  ctx.String("postgres-ssl"),
+		Host:                ctx.String("postgres-host"),
+		Port:                uint(ctx.Int("postgres-port")),
+		User:                ctx.String("postgres-user"),
+		Name:                ctx.String("postgres-name"),
+		Password:            ctx.String("postgres-password"),
+		SSLMode:             ctx.String("postgres-ssl"),
+		ConnectionTolerance: libcli.ConnectionTolerance{}.ParseCli(ctx),
 	}
 }
 
@@ -53,13 +58,26 @@ func PostgresDatabase(config *PostgresDBConfig) (*PostgresDB, error) {
 	}
 	tmpl, err := template.New("config").Parse(strings.Join(options, " "))
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 	connectionOptions := &bytes.Buffer{}
 	err = tmpl.Execute(connectionOptions, config)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
-	db, err := gorm.Open("postgres", connectionOptions.String())
-	return &PostgresDB{db}, err
+
+	var attempt int
+	for {
+		db, err := gorm.Open("postgres", connectionOptions.String())
+		if err != nil {
+			if attempt >= config.ConnectionTolerance.MaxRetries {
+				return nil, fmt.Errorf("Failed to connect to postgres: %s", err.Error())
+			}
+			attempt++
+			log.Infof("Failed to connect: %s. (Attempt %d of %d)", err.Error(), attempt, config.ConnectionTolerance.MaxRetries)
+			time.Sleep(time.Duration(config.ConnectionTolerance.RetryIntervalSec) * time.Second)
+			continue
+		}
+		return &PostgresDB{db}, nil
+	}
 }

--- a/osiris/lib/options.go
+++ b/osiris/lib/options.go
@@ -42,6 +42,26 @@ const (
 	RetryIntervalSec
 )
 
+// ConnectionTolerance ...
+type ConnectionTolerance struct {
+	ConnectionTimeoutSec int
+	MaxRetries           int
+	RetryIntervalSec     int
+}
+
+func (ct ConnectionTolerance) ParseCli(ctx *cli.Context) ConnectionTolerance {
+	t := ConnectionTolerance{
+		ConnectionTimeoutSec: ctx.Int("connection-timeout-sec"),
+		MaxRetries:           ctx.Int("connection-max-retries"),
+		RetryIntervalSec:     ctx.Int("connection-retry-interval-sec"),
+	}
+	if t.ConnectionTimeoutSec > 0 {
+		t.MaxRetries = 1
+		t.RetryIntervalSec = t.ConnectionTimeoutSec
+	}
+	return t
+}
+
 func ParseTimeout(ctx *cli.Context) int {
 	if timeout := ctx.Int("connection-timeout-sec"); timeout > 0 {
 		return timeout

--- a/osiris/lib/options.go
+++ b/osiris/lib/options.go
@@ -62,12 +62,11 @@ func (ct ConnectionTolerance) ParseCli(ctx *cli.Context) ConnectionTolerance {
 	return t
 }
 
-func ParseTimeout(ctx *cli.Context) int {
-	if timeout := ctx.Int("connection-timeout-sec"); timeout > 0 {
-		return timeout
+func (ct ConnectionTolerance) Timeout() int {
+	if ct.ConnectionTimeoutSec > 0 {
+		return ct.ConnectionTimeoutSec
 	}
-	// Calculate from retries and interval
-	return ctx.Int("connection-max-retries") * ctx.Int("connection-retry-interval-sec")
+	return ct.MaxRetries * ct.RetryIntervalSec
 }
 
 func CommonCliOptions(options ...int) []cli.Flag {

--- a/osiris/lib/options.go
+++ b/osiris/lib/options.go
@@ -34,7 +34,21 @@ const (
 	// Service options
 	ServicePort
 	ServiceLogLevel
+
+	// Connection Tolerance
+	ServiceConnectionTolerance
+	ConnectionTimeoutSec
+	MaxRetries
+	RetryIntervalSec
 )
+
+func ParseTimeout(ctx *cli.Context) int {
+	if timeout := ctx.Int("connection-timeout-sec"); timeout > 0 {
+		return timeout
+	}
+	// Calculate from retries and interval
+	return ctx.Int("connection-max-retries") * ctx.Int("connection-retry-interval-sec")
+}
 
 func CommonCliOptions(options ...int) []cli.Flag {
 	commonFlags := []cli.Flag{}
@@ -173,6 +187,33 @@ func CommonCliOptions(options ...int) []cli.Flag {
 				Aliases: []string{"p"},
 				EnvVars: []string{"PORT"},
 				Usage:   "Service port",
+			}}
+
+		case ServiceConnectionTolerance:
+			newOptions = CommonCliOptions(ConnectionTimeoutSec, MaxRetries, RetryIntervalSec)
+		case ConnectionTimeoutSec:
+			newOptions = []cli.Flag{&cli.IntFlag{
+				Name:    "connection-timeout-sec",
+				Value:   0, // Default is max retries and retry interval
+				Aliases: []string{"timeout-sec"},
+				EnvVars: []string{"TIMEOUT_SEC", "CONNECTION_TIMEOUT_SEC"},
+				Usage:   "Timeout for connections during startup",
+			}}
+		case MaxRetries:
+			newOptions = []cli.Flag{&cli.IntFlag{
+				Name:    "connection-max-retries",
+				Value:   12,
+				Aliases: []string{"max-retries"},
+				EnvVars: []string{"MAX_RETRIES", "CONNECTION_MAX_RETRIES"},
+				Usage:   "Max number of retries when connections fail during startup",
+			}}
+		case RetryIntervalSec:
+			newOptions = []cli.Flag{&cli.IntFlag{
+				Name:    "connection-retry-interval-sec",
+				Value:   10,
+				Aliases: []string{"retry-interval-sec"},
+				EnvVars: []string{"RETRY_INTERVAL_SEC", "CONNECTION_RETRY_INTERVAL_SEC"},
+				Usage:   "Number of seconds between connection attempts",
 			}}
 		default:
 			// Do not add any

--- a/osiris/notification/server.go
+++ b/osiris/notification/server.go
@@ -60,10 +60,11 @@ func subscribeKafkaToPool(ctx context.Context, pool *websocket.Pool, options kaf
 		options.Group = "DelayConsumerGroup"
 	}
 	log.Infof("Will consume topic %s from %s (group %s)", options.Topics, strings.Join(options.Brokers, ", "), options.Group)
-	kafkaConsumer, err := kafkaconsumer.ConsumeKafkaGroup(ctx, options)
+	kafkaConsumer, err := kafkaconsumer.KafkaConsumer{}.ConsumeGroup(ctx, options)
 	if err != nil {
-		log.Fatalf("Failed to connect to kafka broker (%s) (group %s) on topic %s: %s",
-			strings.Join(options.Brokers, ", "), options.Group, options.Topics, err.Error())
+		log.Warnf("Failed to connect to kafka broker (%s) (group %s) on topic %s",
+			strings.Join(options.Brokers, ", "), options.Group, options.Topics)
+		log.Fatal(err.Error())
 	}
 
 	noopTicker := time.NewTicker(time.Second * 10)
@@ -113,6 +114,7 @@ func serve(cliCtx *cli.Context) error {
 func main() {
 	cliFlags := []cli.Flag{}
 	cliFlags = append(cliFlags, libcli.CommonCliOptions(libcli.ServicePort, libcli.ServiceLogLevel)...)
+	cliFlags = append(cliFlags, libcli.CommonCliOptions(libcli.ServiceConnectionTolerance)...)
 	cliFlags = append(cliFlags, kafkaconsumer.KafkaConsumerCliOptions...)
 
 	app := &cli.App{

--- a/osiris/query/BUILD
+++ b/osiris/query/BUILD
@@ -59,6 +59,7 @@ go_library(
     importpath = "github.com/bptlab/cepta/osiris/query",
     visibility = ["//visibility:private"],
     deps = [
+        "//osiris/lib:cli",
         "//osiris/lib/db:go_default_library",
         "//models/gql:query_go_proto",
         "//ci/versioning:go_default_library",

--- a/osiris/query/server.go
+++ b/osiris/query/server.go
@@ -14,6 +14,7 @@ import (
 	// "github.com/bptlab/cepta/schemas/types/basic"
 	// "/schemas/types/basic"
 	"github.com/bptlab/cepta/ci/versioning"
+	libcli "github.com/bptlab/cepta/osiris/lib/cli"
 	libdb "github.com/bptlab/cepta/osiris/lib/db"
 	"github.com/bptlab/cepta/osiris/query/resolvers"
 	"github.com/friendsofgo/graphiql"
@@ -103,33 +104,24 @@ func serve(ctx *cli.Context) error {
 }
 
 func main() {
+	cliFlags := []cli.Flag{}
+	cliFlags = append(cliFlags, libcli.CommonCliOptions(libcli.ServicePort, libcli.ServiceLogLevel)...)
+	cliFlags = append(cliFlags, libcli.CommonCliOptions(libcli.ServiceConnectionTolerance)...)
+	cliFlags = append(cliFlags, libdb.PostgresDatabaseCliOptions...)
+	cliFlags = append(cliFlags, []cli.Flag{
+		&cli.StringFlag{
+			Name:    "schema",
+			Value:   "models/gql/query_gql_proto/models/gql/query.pb.graphqls",
+			Aliases: []string{"gql-schema", "graphql-schema"},
+			EnvVars: []string{"SCHEMA"},
+			Usage:   "Path to the GraphQL service schema",
+		},
+	}...)
 	app := &cli.App{
 		Name:    "CEPTA Query service",
 		Version: versioning.BinaryVersion(Version, BuildTime),
 		Usage:   "Provides a GraphQL interface for querying transportation data",
-		Flags: append(libdb.PostgresDatabaseCliOptions, []cli.Flag{
-			&cli.BoolFlag{
-				Name:    "debug",
-				Value:   false,
-				Aliases: []string{"d"},
-				EnvVars: []string{"DEBUG", "ENABLE_DEBUG"},
-				Usage:   "Start a graphiql webserver for testing and debugging queries",
-			},
-			&cli.IntFlag{
-				Name:    "port",
-				Value:   80,
-				Aliases: []string{"p"},
-				EnvVars: []string{"PORT"},
-				Usage:   "GraphQL server port",
-			},
-			&cli.StringFlag{
-				Name:    "schema",
-				Value:   "models/gql/query_gql_proto/models/gql/query.pb.graphqls",
-				Aliases: []string{"gql-schema", "graphql-schema"},
-				EnvVars: []string{"SCHEMA"},
-				Usage:   "Path to the GraphQL service schema",
-			},
-		}...),
+		Flags:   cliFlags,
 		Action: func(ctx *cli.Context) error {
 			ret := serve(ctx)
 			return ret

--- a/osiris/usermgmt/server.go
+++ b/osiris/usermgmt/server.go
@@ -259,7 +259,6 @@ func serve(ctx *cli.Context, log *logrus.Logger) error {
 	var err error
 	db, err = libdb.PostgresDatabase(&postgresConfig)
 	db.DB.AutoMigrate(&User{})
-
 	if err != nil {
 		log.Fatalf("failed to initialize database: %v", err)
 	}

--- a/osiris/usermgmt/server.go
+++ b/osiris/usermgmt/server.go
@@ -227,31 +227,30 @@ func main() {
 	cliFlags = append(cliFlags, libdb.PostgresDatabaseCliOptions...)
 
 	log = logrus.New()
-	go func() {
-		app := &cli.App{
-			Name:    "CEPTA User management server",
-			Version: versioning.BinaryVersion(Version, BuildTime),
-			Usage:   "manages the user database",
-			Flags:   cliFlags,
-			Action: func(ctx *cli.Context) error {
+	app := &cli.App{
+		Name:    "CEPTA User management server",
+		Version: versioning.BinaryVersion(Version, BuildTime),
+		Usage:   "manages the user database",
+		Flags:   cliFlags,
+		Action: func(ctx *cli.Context) error {
+			go func() {
 				level, err := logrus.ParseLevel(ctx.String("log"))
 				if err != nil {
 					log.Warnf("Log level '%s' does not exist.")
 					level = logrus.InfoLevel
 				}
 				log.SetLevel(level)
-				ret := serve(ctx, log)
-				return ret
-			},
-		}
-		err := app.Run(os.Args)
-		if err != nil {
-			log.Fatal(err)
-		}
-	}()
-
-	<-done
-	log.Info("Exiting")
+				serve(ctx, log)
+			}()
+			<-done
+			log.Info("Exiting")
+			return nil
+		},
+	}
+	err := app.Run(os.Args)
+	if err != nil {
+		log.Fatal(err)
+	}
 }
 
 func serve(ctx *cli.Context, log *logrus.Logger) error {

--- a/osiris/usermgmt/server.go
+++ b/osiris/usermgmt/server.go
@@ -223,6 +223,7 @@ func main() {
 
 	cliFlags := []cli.Flag{}
 	cliFlags = append(cliFlags, libcli.CommonCliOptions(libcli.ServicePort, libcli.ServiceLogLevel)...)
+	cliFlags = append(cliFlags, libcli.CommonCliOptions(libcli.ServiceConnectionTolerance)...)
 	cliFlags = append(cliFlags, libdb.PostgresDatabaseCliOptions...)
 
 	log = logrus.New()


### PR DESCRIPTION
This PR closes #214 .

Changes include:
- Uniform backoff on startup connection issues making the microservice startup more resilient and stable
- Refactored interfaces for mongo, postgres and kafka wrappers
- Conditional rebuilds of the dev docker deployemnt images
- Fix of a bug where calling `--help` on some services would block indefinitely long