### PR TITLE
[FEAT] Adds all Flink Testing Dependencies

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -152,6 +152,8 @@ http_archive(
 )
 
 load("@rules_jvm_external//:defs.bzl", "maven_install")
+load("@rules_jvm_external//:defs.bzl", "artifact")
+load("@rules_jvm_external//:specs.bzl", "maven")
 load("@io_grpc_grpc_java//:repositories.bzl", "IO_GRPC_GRPC_JAVA_ARTIFACTS")
 load("@io_grpc_grpc_java//:repositories.bzl", "IO_GRPC_GRPC_JAVA_OVERRIDE_TARGETS")
 
@@ -185,6 +187,55 @@ maven_install(
     ] + IO_GRPC_GRPC_JAVA_ARTIFACTS,
     generate_compat_repositories = True,
     override_targets = IO_GRPC_GRPC_JAVA_OVERRIDE_TARGETS,
+    repositories = [
+        "https://jcenter.bintray.com/",
+        "https://maven.google.com",
+        "https://repo1.maven.org/maven2",
+        # https://repo.maven.apache.org/maven2
+        # https://maven-central-eu.storage-download.googleapis.com/repos/central/data/
+    ],
+)
+
+maven_install(
+    name = "testing",
+    artifacts = [
+        maven.artifact(
+            group = "org.apache.flink",
+            artifact = "flink-runtime_%s" % SCALA_VERSION,
+            version = FLINK_VERSION,
+            classifier = "tests",
+            packaging = "test-jar",
+            testonly = True,
+        ),
+        maven.artifact(
+            group = "org.apache.flink",
+            artifact = "flink-streaming-java_%s" % SCALA_VERSION,
+            version = FLINK_VERSION,
+            classifier = "tests",
+            packaging = "test-jar",
+            testonly = True,
+        ),
+        maven.artifact(
+            group = "org.apache.flink",
+            artifact = "flink-test-utils-junit",
+            version = FLINK_VERSION,
+            testonly = True,
+        ),
+        maven.artifact(
+            group = "org.apache.flink",
+            artifact = "flink-test-utils_%s" % SCALA_VERSION,
+            version = FLINK_VERSION,
+            testonly = True,
+        ),
+        maven.artifact(
+            group = "org.apache.flink",
+            artifact = "flink-tests",
+            version = FLINK_VERSION,
+            classifier = "tests",
+            packaging = "test-jar",
+            testonly = True,
+        ),
+    ],
     repositories = [
         "https://jcenter.bintray.com/",
         "https://maven.google.com",


### PR DESCRIPTION
fixes #281 

Adds Flink Testing Dependencies `@testing`

[Flink Stream Testing](https://ci.apache.org/projects/flink/flink-docs-release-1.9/dev/stream/testing.html)

To use them add them to you Test Build File like this:

**Important:**
load("@rules_jvm_external//:specs.bzl", "maven")
load("@rules_jvm_external//:defs.bzl", "artifact", "maven_install")

`@testing `instead of `@maven`
_tests suffix if target is defined like this:

```
maven.artifact(
            group = "org.apache.flink",
            artifact = "flink-runtime_%s" % SCALA_VERSION,
            version = FLINK_VERSION,
            classifier = "tests",
            packaging = "test-jar",
            testonly = True,
        ),
```
Example BUILD File
```
load("@rules_java//java:defs.bzl", "java_test")
load("@rules_jvm_external//:specs.bzl", "maven")
load("@rules_jvm_external//:defs.bzl", "artifact", "maven_install")

java_test(
    name = "data-to-mongo-db",
    size = "medium",
    srcs = ["DataToMongoDBTests.java"],
    tags = [
        "docker",
        "integration",
    ],
    test_class = "org.bptlab.cepta.DataToMongoDBTests",
    deps = [
        "//core/src/main/java/org/bptlab/cepta/config:java_default_library",
        "//core/src/main/java/org/bptlab/cepta/operators:java_default_library",
        "//core/src/main/java/org/bptlab/cepta/utils/database:java_default_library",
        "//core/src/main/java/org/bptlab/cepta/utils/database/mongohelper:java_default_library",
        "//core/src/main/java/org/bptlab/cepta/utils/functions:java_default_library",
        "//core/src/test/java/org/bptlab/cepta/providers:java_default_library",
        "//models/events:live_train_data_java_proto",
        "//models/events:planned_train_data_java_proto",
        "//models/events:train_delay_notification_java_proto",
        "@maven//:com_google_protobuf_protobuf_java",
        "@maven//:junit_junit_4_13",
        "@maven//:org_apache_flink_flink_connector_kafka_0_11_2_11",
        "@maven//:org_apache_flink_flink_core",
        "@maven//:org_apache_flink_flink_java",
        "@maven//:org_apache_flink_flink_runtime_2_11",
        "@maven//:org_apache_flink_flink_streaming_java_2_11",
        "@maven//:org_javatuples_javatuples",
        "@maven//:org_mongodb_bson",
        "@maven//:org_mongodb_mongodb_driver_core",
        "@maven//:org_mongodb_mongodb_driver_reactivestreams",
        "@maven//:org_testcontainers_kafka",
        "@maven//:org_testcontainers_testcontainers",
        "@testing//:org_apache_flink_flink_runtime_2_11_tests",
        "@testing//:org_apache_flink_flink_streaming_java_2_11_tests",
        "@testing//:org_apache_flink_flink_test_utils_2_11",
        "@testing//:org_apache_flink_flink_test_utils_junit",
        "@testing//:org_apache_flink_flink_tests_tests",
    ],
)

test_suite(name = "smoke",tags = ["-docker","-internal",],)
test_suite(name = "unit",tags = ["-internal","unit", ],)
test_suite(name = "integration", tags = ["-internal","integration",],)

test_suite(name = "internal")
```
